### PR TITLE
add cli and change MonopondResumeFaxSResponse to MonopondResumeFaxRes…

### DIFF
--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -207,8 +207,7 @@ class MonopondSOAPClientV2 {
         
         $messagesResponses = $element->Body->ResumeFaxResponse;
 
-
-        return new MonopondResumeFaxSResponse($messagesResponses);         
+        return new MonopondResumeFaxResponse($messagesResponses);         
     }         
 
 
@@ -247,6 +246,7 @@ class MonopondFaxMessage {
     public $Documents;
     public $ScheduledStartTime;
     public $HeaderFormat;
+    public $CLI;
 }
 
 
@@ -344,6 +344,7 @@ class MonopondSendFaxRequest{
     public $Documents;
     public $ScheduledStartTime;
     public $HeaderFormat;
+    public $CLI;
 }
 
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ To send a fax to a single destination a request similar to the following example
  $faxMessage->Resolution = "normal";
  $faxMessage->Retries = 0;
  $faxMessage->BusyRetries = 2;
+ $faxMessage->CLI = 123456;
  
  // TODO: Setup FaxSendRequest 
  $sendFaxRequest = new MonopondSendFaxRequest();
  $sendFaxRequest->BroadcastRef = "Broadcast-test-1";
  $sendFaxRequest->SendRef = "Send-Ref-1";
  $sendFaxRequest->FaxMessages[] = $faxMessage;
+ $sendFaxRequest->CLI = 65432;
+
  // Call send fax method
  $sendRespone = $client->sendFax($sendFaxRequest);
  print_r($sendRespone);

--- a/index.php
+++ b/index.php
@@ -38,6 +38,7 @@
     $faxMessage->Resolution = "normal";
     $faxMessage->Retries = 0;
     $faxMessage->BusyRetries = 2;
+    $faxMessage->CLI = 61011111111;
     
     $faxMessage2 = new MonopondFaxMessage();
     $faxMessage2->MessageRef = "Testing-message-2";
@@ -46,6 +47,7 @@
     $faxMessage2->Resolution = "normal";
     $faxMessage2->Retries = 0;
     $faxMessage2->BusyRetries = 2;
+    $faxMessage2->CLI = 61011111111;
     
     /* Setup FaxSendRequest (Each contains an array of fax messages) */
     $sendFaxRequest = new MonopondSendFaxRequest();
@@ -55,6 +57,7 @@
     $sendFaxRequest->FaxMessages[] = $faxMessage;
     $sendFaxRequest->FaxMessages[] = $faxMessage2;
     $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->CLI = 3456;
 
     /* Send request to Monopond */
     $sendRespone = $client->sendFax($sendFaxRequest);


### PR DESCRIPTION
Changes:
- add `CLI` in `FaxMessage` and `SendFaxRequest`.
- Change `MonopondResumeFaxSResponse` to  `MonopondResumeFaxResponse`

How to test?
- Just send a faxmessage with cli value and check the cli on the database if it has the same value that you set.
