### PR TITLE
Feature/mail merge fixes

### DIFF
--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -33,12 +33,17 @@ class MonopondSOAPClientV2 {
 				
 			// Setup Documents as SOAP Objects
 			foreach($documentArray as $document) {
+
 				// Makes each individual document into a SOAP ready object
-				$soapDocuments[] = new SoapVar($document, SOAP_ENC_OBJECT,null,null,"Document");
+
+				if(!$document->DocumentRef) {
+					$document = $this->removeNullValues($document);
+				}
 
 				if(!empty($document->DocMergeData)) {
-					$document->DocMergeData = $this->convertDocMergeDataArrayToSoapArray($document->DocMergeData);
+					$document->DocMergeData = $this->convertMergeFieldArrayToSoapArray($document->DocMergeData);
 				}
+				$soapDocuments[] = new SoapVar($document, SOAP_ENC_OBJECT,null,null,"Document");
 			}
 
 			// Make documents array SOAP ready
@@ -47,16 +52,16 @@ class MonopondSOAPClientV2 {
 			return $soapDocuments;
 		}
 
-		private function convertDocMergeDataArrayToSoapArray($docMergeDataArray) {
-			$mergeFields = array();
+		private function convertMergeFieldArrayToSoapArray($mergeFieldArray) {
+			$soapMergeFields = array();
 
-			foreach ($docMergeDataArray as $mergeField) {
-				$mergeFields[] = new SoapVar($mergeField, SOAP_ENC_OBJECT, null, null, "MergeFields");
+			foreach ($mergeFieldArray as $mergeField) {
+				$soapMergeFields[] = new SoapVar($mergeField, SOAP_ENC_OBJECT, null, null, "MergeField");
 			}
 
-			$mergeFields = new SoapVar($mergeFields, SOAP_ENC_OBJECT);
+			$soapMergeFields = new SoapVar($soapMergeFields, SOAP_ENC_OBJECT);
 
-			return $mergeFields;
+			return $soapMergeFields;
 		}
 
 		private function removeNullValues($object) {
@@ -232,7 +237,7 @@ class MonopondSOAPClientV2 {
 		}
 	}
 
-	class MergeField {
+	class MonopondMergeField {
 	    public $Key;
 	    public $Value;
 	}

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The example below shows ```field1``` will be replaced by the value of ```Test```
     $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));
 	$filedata = base64_encode($filedata);
 
-	$mergeField = new MergeField();
+	$mergeField = new MonopondMergeField();
 	$mergeField->Key = "name";
 	$mergeField->Value = "Raspberry Pi";
 
@@ -191,7 +191,7 @@ The example below shows ```field1``` will be replaced by the value of ```Test```
 	$faxMessage->CLI = 61290120211;
 	$faxMessage->Documents = array($document1);
 
-	$mergeField2 = new MergeField();
+	$mergeField2 = new MonopondMergeField();
 	$mergeField2->Key = "name";
 	$mergeField2->Value = "Raspberry Pi 2";
 


### PR DESCRIPTION
@timkhoury 
#### Changes:
- Change `MergeFields` to `MergeField` in converting merge field array to merge field soap array.
- Rename the method for converting the merge field array to this name `convertMergeFieldArrayToSoapArray`.
- Remove DocumentRef if it is set to null value.
- Rename `MergeField` class to `MonopondMergeField`.
