### PR TITLE
arrange properties according to the wsdl endpoint.

### DIFF
--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -263,11 +263,11 @@ class MonopondSOAPClientV2 {
 		public $MessageRef;
 		public $SendTo;
 		public $SendFrom;
+		public $Documents;
 		public $Resolution;
+		public $ScheduledStartTime;
 		public $Retries;
 		public $BusyRetries;
-		public $Documents;
-		public $ScheduledStartTime;
 		public $HeaderFormat;
 		public $CLI;
 	}
@@ -353,12 +353,12 @@ class MonopondSOAPClientV2 {
 		public $BroadcastRef;
 		public $SendRef;
 		public $FaxMessages;
-		public $SendFrom;
+		public $Documents;
 		public $Resolution;
+		public $SendFrom;
+		public $ScheduledStartTime;
 		public $Retries;
 		public $BusyRetries;
-		public $Documents;
-		public $ScheduledStartTime;
 		public $HeaderFormat;
 		public $CLI;
 	}


### PR DESCRIPTION
Hi @froilan @timkhoury @jcfrancisco17 

We have an existing bug in our PHP-client app because the xml elements are not properly arranged. 

This is the error occurred when I sent a fax using our beta.monopond.com wsdl.
```
Unmarshalling Error: cvc-complex-type.2.4.a: Invalid content was found starting with element 'Documents'. One of '{HeaderFormat, MustBeSentBeforeDate, MaxFaxPages, CLI, TimeZone}' is expected. PHP Notice:  Trying to get property of non-object in /home/synacy7/workspace/fax-api-client-php/MonopondSOAPClient.php on line 371
PHP Warning:  Invalid argument supplied for foreach() in /home/synacy7/workspace/fax-api-client-php/MonopondSOAPClient.php on line 371
MonopondSendFaxResponse Object
(
    [FaxMessages] => 
)
```
Based on the error above, we have a problem in our xml request in which 'Documents' element is not  arranged in its expected location. 

As we look in our wsdl endpoint of beta.monopond.com, `Documents` element should be located after `SendFrom` element.

```
<xs:complexType name="apiFaxMessage">
<xs:sequence>
<xs:element name="MessageRef" type="xs:string"/>
<xs:element name="SendTo" type="xs:string"/>
<xs:element minOccurs="0" name="SendFrom" type="xs:string"/>
<xs:element minOccurs="0" name="Documents">
<xs:complexType>
<xs:sequence>
<xs:element maxOccurs="unbounded" minOccurs="0" name="Document" type="tns:apiFaxDocument"/>
</xs:sequence>
</xs:complexType>
</xs:element>
<xs:element minOccurs="0" name="Resolution" type="tns:faxResolution"/>
<xs:element minOccurs="0" name="Blocklists" type="tns:apiFaxMessageBlocklist"/>
<xs:element minOccurs="0" name="ScheduledStartTime" type="xs:string"/>
<xs:element minOccurs="0" name="Retries" type="xs:int"/>
<xs:element minOccurs="0" name="BusyRetries" type="xs:int"/>
<xs:element minOccurs="0" name="HeaderFormat" type="xs:string"/>
<xs:element minOccurs="0" name="MustBeSentBeforeDate" type="xs:dateTime"/>
<xs:element minOccurs="0" name="MaxFaxPages" type="xs:int"/>
<xs:element minOccurs="0" name="CLI" type="xs:string"/>
<xs:element minOccurs="0" name="TimeZone" type="xs:string"/>
</xs:sequence>
</xs:complexType>
```
Unfortunately, the `Documents` element is not located after `SendFrom` based on this xml request that I got during sending of fax.
```
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns2="https://api.monopond.com/fax/soap/v2.1">
	<SOAP-ENV:Header>
		<ns1:Security SOAP-ENV:mustUnderstand="1">
			<ns1:UsernameToken><ns1:Username>monoponduser</ns1:Username>
			<ns1:Password>synacy22</ns1:Password>
			</ns1:UsernameToken>
		</ns1:Security>
	</SOAP-ENV:Header>
	<SOAP-ENV:Body>
		<ns2:SendFaxRequest>
		<BroadcastRef>Broadcast-test-1</BroadcastRef>
		<SendRef>Send-Ref-1</SendRef>
		<FaxMessages>
			<FaxMessage>
				<MessageRef>Testing-message-1</MessageRef>
				<SendTo>61290120211</SendTo>
				<SendFrom>Test Fax</SendFrom>
				<Resolution>normal</Resolution>
				<Retries>0</Retries>
				<BusyRetries>2</BusyRetries>
				<Documents>
					<Document>
						<FileName>AnyFileName1.txt</FileName>
						<FileData>VGhpcyBpcyBhIHRlc3QgZmF4Lg==</FileData>
						<Order>0</Order>
					</Document>
				</Documents>
				<CLI>61290120211</CLI>
			</FaxMessage>
		</FaxMessages>
		<CLI>3456</CLI>
		</ns2:SendFaxRequest>
	</SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```
I copied the xml request above and send a fax request using soapui and got an error.

To fix this issue, I modified the `MonopondFaxMessage` class and arranged its fields based in our wsdl endpoint.

This is our modified `MonopondFaxMessage`  class.
```
class MonopondFaxMessage {
		public $MessageRef;
		public $SendTo;
		public $SendFrom;
		public $Documents;
		public $Resolution;
		public $ScheduledStartTime;
		public $Retries;
		public $BusyRetries;
		public $HeaderFormat;
		public $CLI;
	}
```
After the modification of `MonopondFaxMessage` class, I sent a fax and print the xml request.
```
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:ns2="https://api.monopond.com/fax/soap/v2.1">
	<SOAP-ENV:Header>
		<ns1:Security SOAP-ENV:mustUnderstand="1">
			<ns1:UsernameToken>
				<ns1:Username>monoponduser</ns1:Username>
				<ns1:Password>synacy22</ns1:Password>
			</ns1:UsernameToken>
		</ns1:Security>
	</SOAP-ENV:Header>
	<SOAP-ENV:Body>
		<ns2:SendFaxRequest>
			<BroadcastRef>Broadcast-test-1</BroadcastRef>
			<SendRef>Send-Ref-1</SendRef>
			<FaxMessages>
				<FaxMessage>
					<MessageRef>Testing-message-16</MessageRef>
					<SendTo>61290120211</SendTo>
					<SendFrom>Test Fax</SendFrom>
					<Documents>
						<Document>
							<FileName>AnyFileName1.txt</FileName>
							<FileData>VGhpcyBpcyBhIHRlc3QgZmF4Lg==</FileData>
							<Order>0</Order>
						</Document>
					</Documents>
					<Resolution>normal</Resolution>
					<Retries>0</Retries>
					<BusyRetries>2</BusyRetries>
					<CLI>61290120211</CLI>
				</FaxMessage>
			</FaxMessages>
			<HeaderFormat>Testing</HeaderFormat>
			<CLI>3456</CLI>
		</ns2:SendFaxRequest>
	</SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```
It seems that the xml request is right and successfully send the fax.

I also modified the MonopondSendFaxRequest class by arranging its properties.

Aside from that, we need to add more features of PHP-client app because it can't cater `MustBeSentBeforeDate`, `MaxFaxPages`, `Blocklists`, and `TimeZone` features.

Cheers,
Michael