### PR TITLE
add missing features of php-clients and add more examples in README.md

### DIFF
--- a/MonopondSOAPClient PHP Docu.txt
+++ b/MonopondSOAPClient PHP Docu.txt
@@ -4,7 +4,7 @@ To use Monopond SOAP PHP Client, start by including the MonopondSOAPClient.php (
 2.     include_once './MonopondSOAPClient.php';
 3.     
 4.     // TODO: Enter your own credentials here
-5.     $client = new MonopondSOAPClientV2("myusername", "mypassword", MPENV::Production);
+5.     $client = new MonopondSOAPClientV2_1("myusername", "mypassword", MPENV::Production);
 6.     
 7.     // TODO: Set up your request here
 8. ?>

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -87,18 +87,17 @@
 		}
 
 		private function convertMergeFieldArrayToSoapString($mergeFieldArray) {
-			$DocMergeDataString = '';
 			
+			$DocMergeDataString = '<DocMergeData>';
 			foreach ($mergeFieldArray as $mergeField) {
-				$DocMergeDataString .= '<DocMergeData>';
 				if($mergeField->Key != null || $mergeField->Value != null) {
 					$DocMergeDataString .= '<MergeField>';
 					$DocMergeDataString .= '<Key>'.$mergeField->Key.'</Key>';
 					$DocMergeDataString .= '<Value>'.$mergeField->Value.'</Value>';
 					$DocMergeDataString .= '</MergeField>';
 				}
-				$DocMergeDataString .= '</DocMergeData>';
 			}
+			$DocMergeDataString .= '</DocMergeData>';
 
 			return $DocMergeDataString;
 		}

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -31,7 +31,13 @@
 			));
 
 			// Creating the SOAP client 
-			$this->_SoapClient = new SoapClient($this->_wsdl, array("trace" => 1, "stream_context" => $context));
+			$this->_SoapClient = new SoapClient($this->_wsdl, array(
+				"trace" => 1, 
+				"stream_context" => $context,
+				'location' => $wsdl,
+                'uri'      => $wsdl
+				)
+			);
 			$this->_SoapClient->__setSoapHeaders(array($SoapHeader));
 		}
 			

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -180,7 +180,7 @@ class MonopondSOAPClientV2 {
 					$this->_SoapClient->SendFax($SendFaxRequest);
 			}catch (SoapFault $exception) {
 				// Print exception if one occured
-				//print_r($exception->getMessage());
+				print_r($exception->getMessage());
 				// Uncomment the line below to print the XML of the request just made  
 				// print_r($this->_SoapClient->__getLastRequest());
 			}

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -291,6 +291,7 @@ class MonopondSOAPClientV2 {
 		public $FileName;
 		public $FileData;
 		public $Order;
+		public $DitheringTechnique;
 		public $DocMergeData;
 	}
 

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -48,6 +48,10 @@ class MonopondSOAPClientV2 {
 					$document = $this->removeNullValues($document);
 				}
 
+				if(!$document->DitheringTechnique) {
+					$document = $this->removeNullValues($document);
+				}
+
 				if(!empty($document->DocMergeData)) {
 					$document->DocMergeData = $this->convertMergeFieldArrayToSoapArray($document->DocMergeData);
 				}
@@ -291,7 +295,7 @@ class MonopondSOAPClientV2 {
 		public $FileName;
 		public $FileData;
 		public $Order;
-		public $DitheringTechnique="normal";
+		public $DitheringTechnique;
 		public $DocMergeData;
 	}
 
@@ -313,9 +317,9 @@ class MonopondSOAPClientV2 {
 	}
 
 	class MonopondBlocklist {
-		public $dncr = "false";
-		public $fps = "false";
-		public $smartblock = "false";
+		public $dncr;
+		public $fps;
+		public $smartblock;
 	}
 
 	class MonopondFaxDetailsResponse {

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -1,13 +1,13 @@
 
 <?php
 
-class MonopondSOAPClientV2 {
+	class MonopondSOAPClientV2 {
 		private $_username;
 		private $_password;
 		private $_wsdl;
 		private $_SoapClient;
 		private $_strWSSENS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
-		
+			
 		function __construct($username, $password, $wsdl) {
 			// Setup monopond API credentials
 			$this->_username=$username;
@@ -27,14 +27,14 @@ class MonopondSOAPClientV2 {
 		        'verify_peer' => false,
 		        'verify_peer_name' => false,
 		        'allow_self_signed' => true
-       		 	)
+	   		 	)
 			));
 
 			// Creating the SOAP client 
 			$this->_SoapClient = new SoapClient($this->_wsdl, array("trace" => 1, "stream_context" => $context));
 			$this->_SoapClient->__setSoapHeaders(array($SoapHeader));
 		}
-		
+			
 		private function convertDocumentArrayToSoapArray($documentArray) {
 			// Initialise a blank array
 			$soapDocuments = array();
@@ -69,14 +69,9 @@ class MonopondSOAPClientV2 {
 					$documentXmlString .= $this->convertMergeFieldArrayToSoapString($document->DocMergeData);
 				}
 
-
 				$documentXmlString .= '</Document>';
 				$soapDocument = new SoapVar($documentXmlString , XSD_ANYXML);
-
-
 				$soapDocuments[] = $soapDocument;
-
-
 			}
 
 			// Make documents array SOAP ready
@@ -103,12 +98,12 @@ class MonopondSOAPClientV2 {
 		}
 
 		private function removeNullValues($object) {
-				foreach($object as $key => $value) {
-						if (!isset($value)) {
-								unset($object->$key);
-						}
-				}
-				return $object;
+			foreach($object as $key => $value) {
+					if (!isset($value)) {
+							unset($object->$key);
+					}
+			}
+			return $object;
 		}
 
 		private function createBlocklistElement($blocklistData) {
@@ -137,7 +132,7 @@ class MonopondSOAPClientV2 {
 
 			return $blocklist;
 		}
-		
+			
 		public function sendFax($SendFaxRequest) {
 			$SendFaxRequest = $this->removeNullValues($SendFaxRequest);        
 			
@@ -185,10 +180,8 @@ class MonopondSOAPClientV2 {
 				 // print_r($this->_SoapClient->__getLastRequest());
 			}
 
-
 			// Uncomment the line below to print the XML of the request just made  
 			// print_r($this->_SoapClient->__getLastResponse());
-
 
 			$XMLResponseString = $this->_SoapClient->__getLastResponse();
 			$XMLResponseString = str_replace("soap:", "", $XMLResponseString);
@@ -200,7 +193,7 @@ class MonopondSOAPClientV2 {
 
 			return new MonopondSendFaxResponse($messagesResponses);
 		}
-		
+			
 		public function faxStatus($faxStatusRequest) {
 			$faxStatusRequest = $this->removeNullValues($faxStatusRequest);
 			$faxStatusRequest = new SoapVar($faxStatusRequest,SOAP_ENC_OBJECT,NULL,$this->_strWSSENS,NULL,$this->_strWSSENS);
@@ -461,12 +454,10 @@ class MonopondSOAPClientV2 {
 		public $Verbosity = "brief";
 	}
 
-
 	class MonopondFaxStatusResponse {
 		public $FaxStatusTotals;
 		public $FaxResultsTotals;
 		public $FaxMessages;
-
 
 		function __construct($response) {
 			$this->FaxStatusTotals = new MonopondFaxStatusTotalsResponse($response->FaxStatusTotals);

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -291,7 +291,7 @@ class MonopondSOAPClientV2 {
 		public $FileName;
 		public $FileData;
 		public $Order;
-		public $DitheringTechnique;
+		public $DitheringTechnique="normal";
 		public $DocMergeData;
 	}
 

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -80,6 +80,33 @@ class MonopondSOAPClientV2 {
 				}
 				return $object;
 		}
+
+		private function createBlocklistElement($blocklistData) {
+
+			$dncr = $blocklistData->dncr;
+			$fps = $blocklistData->fps;
+			$smartblock = $blocklistData->smartblock;
+			$blocklist = "";
+
+			if($dncr != null || $fps != null || $smartblock != null) {
+				$blocklist = '<Blocklists ';
+
+				if($dncr != null) {
+					$blocklist .= 'dncr="'.$dncr.'" ';
+				}
+
+				if($fps != null) {
+					$blocklist .= 'fps="'.$fps.'" ';
+				}
+
+				if($smartblock != null) {
+					$blocklist .= 'smartblock="'.$smartblock.'"';
+				}
+				$blocklist .= '/>';
+			}
+
+			return $blocklist;
+		}
 		
 		public function sendFax($SendFaxRequest) {
 			$SendFaxRequest = $this->removeNullValues($SendFaxRequest);        
@@ -90,7 +117,11 @@ class MonopondSOAPClientV2 {
 				if (!empty($faxMessage->Documents)) {
 					$faxMessage->Documents = $this->convertDocumentArrayToSoapArray($faxMessage->Documents);    
 				}
-				
+
+				if($faxMessage->Blocklists != null) {
+					$blocklist = $this->createBlocklistElement($faxMessage->Blocklists);
+					$faxMessage->Blocklists = new SoapVar($blocklist, XSD_ANYXML);
+				}
 				
 				// Add SOAP ready fax message to an array of fax messages
 				$soapFaxMessages[] = new SoapVar($faxMessage,SOAP_ENC_OBJECT,null,null,"FaxMessage");
@@ -109,7 +140,6 @@ class MonopondSOAPClientV2 {
 			
 			// Make fax request SOAP ready
 			$SendFaxRequest = new SoapVar($SendFaxRequest,SOAP_ENC_OBJECT,NULL,$this->_strWSSENS,NULL,$this->_strWSSENS);
-
 			try{
 					// Try to call send fax
 					$this->_SoapClient->SendFax($SendFaxRequest);
@@ -233,7 +263,7 @@ class MonopondSOAPClientV2 {
 
 	class MPENV {
 		const PRODUCTION = "https://api.monopond.com/fax/soap/v2.1/?wsdl";
-		const PRODUCTION_BETA = "https://beta.monopond.com/api/fax/v2.1?wsdl";
+		const PRODUCTION_BETA = "https://stagingbeta.monopond.com/api/fax/v2.1?wsdl";
 		const TEST = "http://test.api.monopond.com/fax/soap/v2.1/?wsdl";
 		const LOCAL = "http://localhost:8000/fax/soap/v2.1?wsdl";
 	}
@@ -264,12 +294,22 @@ class MonopondSOAPClientV2 {
 		public $SendTo;
 		public $SendFrom;
 		public $Resolution;
+		public $Blocklists;
 		public $Retries;
 		public $BusyRetries;
 		public $Documents;
 		public $ScheduledStartTime;
+		public $MustBeSentBeforeDate;
 		public $HeaderFormat;
+		public $MaxFaxPages;
 		public $CLI;
+		public $TimeZone;
+	}
+
+	class MonopondBlocklist {
+		public $dncr = "false";
+		public $fps = "false";
+		public $smartblock = "false";
 	}
 
 	class MonopondFaxDetailsResponse {
@@ -359,8 +399,11 @@ class MonopondSOAPClientV2 {
 		public $BusyRetries;
 		public $Documents;
 		public $ScheduledStartTime;
+		public $MustBeSentBeforeDate;
 		public $HeaderFormat;
+		public $MaxFaxPages;
 		public $CLI;
+		public $TimeZone;
 	}
 
 	class MonopondSendFaxResponse{   

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -52,10 +52,31 @@ class MonopondSOAPClientV2 {
 					$document = $this->removeNullValues($document);
 				}
 
-				if(!empty($document->DocMergeData)) {
-					$document->DocMergeData = $this->convertMergeFieldArrayToSoapArray($document->DocMergeData);
+				$documentXmlString = '<Document>';
+				if($document->DocumentRef != null) {
+					$documentXmlString .= '<DocumentRef>'.$document->DocumentRef.'</DocumentRef>';
 				}
-				$soapDocuments[] = new SoapVar($document, SOAP_ENC_OBJECT,null,null,"Document");
+
+				$documentXmlString .= '<FileName>'.$document->FileName.'</FileName>';
+				$documentXmlString .= '<FileData>'.$document->FileData.'</FileData>';
+				$documentXmlString .= '<Order>'.$document->Order.'</Order>';
+
+				if($document->DitheringTechnique != null) {
+					$documentXmlString .= '<DitheringTechnique>'.$document->DitheringTechnique.'</DitheringTechnique>';
+				}
+
+				if(!empty($document->DocMergeData)) {
+					$documentXmlString .= $this->convertMergeFieldArrayToSoapString($document->DocMergeData);
+				}
+
+
+				$documentXmlString .= '</Document>';
+				$soapDocument = new SoapVar($documentXmlString , XSD_ANYXML);
+
+
+				$soapDocuments[] = $soapDocument;
+
+
 			}
 
 			// Make documents array SOAP ready
@@ -64,16 +85,21 @@ class MonopondSOAPClientV2 {
 			return $soapDocuments;
 		}
 
-		private function convertMergeFieldArrayToSoapArray($mergeFieldArray) {
-			$soapMergeFields = array();
-
+		private function convertMergeFieldArrayToSoapString($mergeFieldArray) {
+			$DocMergeDataString = '';
+			
 			foreach ($mergeFieldArray as $mergeField) {
-				$soapMergeFields[] = new SoapVar($mergeField, SOAP_ENC_OBJECT, null, null, "MergeField");
+				$DocMergeDataString .= '<DocMergeData>';
+				if($mergeField->Key != null || $mergeField->Value != null) {
+					$DocMergeDataString .= '<MergeField>';
+					$DocMergeDataString .= '<Key>'.$mergeField->Key.'</Key>';
+					$DocMergeDataString .= '<Value>'.$mergeField->Value.'</Value>';
+					$DocMergeDataString .= '</MergeField>';
+				}
+				$DocMergeDataString .= '</DocMergeData>';
 			}
 
-			$soapMergeFields = new SoapVar($soapMergeFields, SOAP_ENC_OBJECT);
-
-			return $soapMergeFields;
+			return $DocMergeDataString;
 		}
 
 		private function removeNullValues($object) {
@@ -153,15 +179,15 @@ class MonopondSOAPClientV2 {
 					// Try to call send fax
 					$this->_SoapClient->SendFax($SendFaxRequest);
 			}catch (SoapFault $exception) {
-					// Print exception if one occured
-					print_r($exception->getMessage());
-					// Uncomment the line below to print the XML of the request just made  
-					//print_r($this->_SoapClient->__getLastRequest());
+				// Print exception if one occured
+				//print_r($exception->getMessage());
+				// Uncomment the line below to print the XML of the request just made  
+				// print_r($this->_SoapClient->__getLastRequest());
 			}
 
 
 			// Uncomment the line below to print the XML of the request just made  
-			//print_r($this->_SoapClient->__getLastResponse());
+			// print_r($this->_SoapClient->__getLastResponse());
 
 
 			$XMLResponseString = $this->_SoapClient->__getLastResponse();
@@ -429,9 +455,9 @@ class MonopondSOAPClientV2 {
 
 	/* FaxStatus */
 	class MonopondFaxStatusRequest {
-		public $BroadcastRef;
-		public $SendRef;
 		public $MessageRef;
+		public $SendRef;
+		public $BroadcastRef;
 		public $Verbosity = "brief";
 	}
 

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -182,7 +182,7 @@ class MonopondSOAPClientV2 {
 				// Print exception if one occured
 				print_r($exception->getMessage());
 				// Uncomment the line below to print the XML of the request just made  
-				// print_r($this->_SoapClient->__getLastRequest());
+				 // print_r($this->_SoapClient->__getLastRequest());
 			}
 
 
@@ -528,9 +528,9 @@ class MonopondSOAPClientV2 {
 
 	/* StopFax */
 	class MonopondStopFaxRequest {
-		public $BroadcastRef;
-		public $SendRef;
 		public $MessageRef;
+		public $SendRef;
+		public $BroadcastRef;
 	}
 
 	class MonopondStopFaxResponse {
@@ -545,9 +545,9 @@ class MonopondSOAPClientV2 {
 
 	/* PauseFax */
 	class MonopondPauseFaxRequest {
-		public $BroadcastRef;
-		public $SendRef;
 		public $MessageRef;
+		public $SendRef;
+		public $BroadcastRef;
 	}
 
 	class MonopondPauseFaxResponse {
@@ -562,9 +562,9 @@ class MonopondSOAPClientV2 {
 
 	/* ResumeFax */
 	class MonopondResumeFaxRequest {
-		public $BroadcastRef;
-		public $SendRef;
 		public $MessageRef;
+		public $SendRef;
+		public $BroadcastRef;
 	}
 
 	class MonopondResumeFaxResponse {

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -1,7 +1,7 @@
 
 <?php
 
-	class MonopondSOAPClientV2 {
+	class MonopondSOAPClientV2_1 {
 		private $_username;
 		private $_password;
 		private $_wsdl;

--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -252,11 +252,11 @@ class MonopondSOAPClientV2 {
 	}
 
 	class MonopondDocument {
+		public $DocumentRef;
 		public $FileName;
 		public $FileData;
 		public $Order;
 		public $DocMergeData;
-		public $DocumentRef;
 	}
 
 	class MonopondFaxMessage {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,40 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with Retries inside a FaxMessage
+To set-up a fax to have retries a request similar to the following example can be used.
+
+```php
+ 	// TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->Retries = 0;
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know their definitions:
+* [MonopondDocument Properties](#monoponddocument-properties)
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,39 @@ DocumentRef must be unique and a request must be similar to this example:
 You can visit here to check the definition of DocumentRef:
 * [MonopondDocument Properties](#monoponddocument-properties)
 
+### Assigning SendRef and BroadcastRef in MonopondSendFaxRequest
+To assign SendRef and BroadcastRef in MonopondSendFaxRequest, a request must be similar to this example:
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "Testing";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->BroadcastRef = "BroadcastRef";
+    $sendFaxRequest->SendRef = "SendRef";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+ ```
+Visit here to know the definitions of SendRef and BroadcastRef:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 ### Sending a Fax with Retries inside a MonopondFaxMessage
 To set-up a fax to have retries a request similar to the following example can be used.
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,41 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with Resolution in FaxMessage
+To assign the fax resolution, a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->Resolution = "normal";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+You can visit the definition of Resolution and its values here:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [Resolution Levels](#resolution-levels)
+
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 
@@ -530,16 +565,6 @@ The example below shows a PDF that will be stamped with the text “Hello” at 
 ```php
 	TODO: code here  
 ```
-
-
-
-
-***Resolution Levels:***
-
-| **Value** | **Description** |
-| --- | --- |
-| **normal** | Normal standard resolution (98 scan lines per inch) |
-| **fine** | Fine resolution (196 scan lines per inch) |
 
 ***Header Format:iff***
 Determines the format of the header line that is printed on the top of the transmitted fax message.
@@ -1151,3 +1176,10 @@ Represents a fax document to be sent through the system. Supported file types ar
 **Order** |**X** | Integer|If multiple documents are defined on a message this value will determine the order in which they will be transmitted.|0|
 **DocMergeData**|||An Array of MergeFields|
 **StampMergeData**|||An Array of MergeFields|
+
+### Resolution Levels
+
+| **Value** | **Description** |
+| --- | --- |
+| **normal** | Normal standard resolution (98 scan lines per inch) |
+| **fine** | Fine resolution (196 scan lines per inch) |

--- a/README.md
+++ b/README.md
@@ -892,11 +892,8 @@ To know more about MaxFaxPages you can check it here:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another `FaxMessage`:
 
 ```php
-    // TODO: Enter your own credentials here
-    $client = new MonopondSOAPClientV2("monoponduser", "synacy22", MPENV::PRODUCTION_BETA);
-    
     // TODO: Put your file path here
-    $filedata = fread(fopen("tests/hello.txt", "r"), filesize("tests/hello.txt"));
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
     $filedata = base64_encode($filedata);
     
     /* Setup Documents */

--- a/README.md
+++ b/README.md
@@ -628,6 +628,44 @@ You can visit here the definition of Blocklists and its paremeters:
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [Blocklists Parameters](#blocklists-parameters);
 
+### Add a Blocklists in MonopondSendFaxRequest
+If you want to validate all numbers in DNCR or FPS or Smarblock, a request must be similiar to this example:
+
+```php
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup Blocklists */
+    $monopondBlocklists = new MonopondBlocklist();
+    $monopondBlocklists->dncr = "true";
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->Blocklists = $monopondBlocklists;
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit here the definition of Blocklists and its paremeters:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+* [Blocklists Parameters](#blocklists-parameters);
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,6 @@ Represents a fax document to be sent through the system. Supported file types ar
 -----|-----|-----|-----|-----
 **FileName**|**X**|String|The document filename including extension. This is important as it is used to help identify the document MIME type.|
 **FileData**|**X**|Base64|The document encoded in Base64 format.|
-**Order** | | Integer|If multiple documents are defined on a message this value will determine the order in which they will be transmitted.|0|
+**Order** |**X** | Integer|If multiple documents are defined on a message this value will determine the order in which they will be transmitted.|0|
 **DocMergeData**|||An Array of MergeFields|
 **StampMergeData**|||An Array of MergeFields|

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ To send a fax to a single destination a request similar to the following example
 	$sendRespone = $client->sendFax($sendFaxRequest);
 	print_r($sendRespone);
 ```
+You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know there definitions:
+* [MonopondDocument Properties](#monoponddocument-properties)
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [MonopondSendFaxRequest Properties](#monopondsendfaxfequest-properties)
+
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
@@ -391,52 +396,7 @@ The example below shows a PDF that will be stamped with the text “Hello” at 
 ```
 
 
-### sendFaxRequest Properties:
-**Name**|**Required**|**Type**|**Description**|**Default**
------|-----|-----|-----|-----
-**BroadcastRef**||String|Allows the user to tag all faxes in this request with a user-defined broadcastreference. These faxes can then be retrieved at a later point based on this reference.|
-**SendRef**||String|Similar to the BroadcastRef, this allows the user to tag all faxes in this request with a send reference. The SendRef is used to represent all faxes in this request only, so naturally it must be unique.|
-**FaxMessages**|**X**| Array of FaxMessage |FaxMessages describe each individual fax message and its destination. See below for details.|
-**SendFrom**||Alphanumeric String|A customisable string used to identify the sender of the fax. Also known as the Transmitting Subscriber Identification (TSID). The maximum string length is 32 characters|Fax
-**Documents**|**X**|Array of apiFaxDocument|Each FaxDocument object describes a fax document to be sent. Multiple documents can be defined here which will be concatenated and sent in the same message. See below for details.|
-**Resolution**||Resolution|Resolution setting of the fax document. Refer to the resolution table below for possible resolution values.|normal
-**ScheduledStartTime**||DateTime|The date and time the transmission of the fax will start.|Current time (immediate sending)
-**Blocklists**||Blocklists|The blocklists that will be checked and filtered against before sending the message. See below for details.WARNING: This feature is inactive and non-functional in this (2.1) version of the Fax API.|
-**Retries**||Unsigned Integer|The number of times to retry sending the fax if it fails. Each account has a maximum number of retries that can be changed by consultation with your account manager.|Account Default
-**BusyRetries**||Unsigned Integer|Certain fax errors such as “NO_ANSWER” or “BUSY” are not included in the above retries limit and can be set separately. Each account has a maximum number of busy retries that can be changed by consultation with your account manager.|Account default
-**HeaderFormat**||String|Allows the header format that appears at the top of the transmitted fax to be changed. See below for an explanation of how to format this field.| From: X, To: X
-**MustBeSentBeforeDate** | | DateTime |  Specifies a time the fax must be delivered by. Once the specified time is reached the fax will be cancelled across the system. | 
-**MaxFaxPages** | | Unsigned Integer |  Sets a limit on the amount of pages allowed in a single fax transmission. Especially useful if the user is blindly submitting their customer's documents to the platform. | 20
 
-***apiFaxMessage Properties:***
-This represents a single fax message being sent to a destination.
-
-**Name** | **Required** | **Type** | **Description** | **Default** 
------|-----|-----|-----|-----
-**MessageRef** | **X** | String | A unique user-provided identifier that is used to identify the fax message. This can be used at a later point to retrieve the results of the fax message. |
-**SendTo** | **X** | String | The phone number the fax message will be sent to. |
-**SendFrom** | | Alphanumeric String | A customisable string used to identify the sender of the fax. Also known as the Transmitting Subscriber Identification (TSID). The maximum string length is 32 characters | Empty
-**Documents** | **X** | Array of apiFaxDocument | Each FaxDocument object describes a fax document to be sent. Multiple documents can be defined here which will be concatenated and sent in the same message. See below for details. | 
-**Resolution** | | Resolution|Resolution setting of the fax document. Refer to the resolution table below for possible resolution values.| normal
-**ScheduledStartTime** | | DateTime | The date and time the transmission of the fax will start. | Start now
-**Blocklists** | | Blocklists | The blocklists that will be checked and filtered against before sending the message. See below for details. WARNING: This feature is inactive and non-functional in this (2.1) version of the Fax API. |
-**Retries** | | Unsigned Integer | The number of times to retry sending the fax if it fails. Each account has a maximum number of retries that can be changed by consultation with your account manager. | Account Default
-**BusyRetries** | | Unsigned Integer | Certain fax errors such as “NO_ANSWER” or “BUSY” are not included in the above retries limit and can be set separately. Please consult with your account manager in regards to maximum value.|account default
-**HeaderFormat** | | String | Allows the header format that appears at the top of the transmitted fax to be changed. See below for an explanation of how to format this field. | From： X, To: X
-**MustBeSentBeforeDate** | | DateTime |  Specifies a time the fax must be delivered by. Once the specified time is reached the fax will be cancelled across the system. | 
-**MaxFaxPages** | | Unsigned Integer |  Sets a limit on the amount of pages allowed in a single fax transmission. Especially useful if the user is blindly submitting their customer's documents to the platform. | 20
-**CLI**| | String| Allows a customer called ID. Note: Must be enabled on the account before it can be used.
-
-***apiFaxDocument Properties:***
-Represents a fax document to be sent through the system. Supported file types are: PDF, TIFF, PNG, JPG, GIF, TXT, PS, RTF, DOC, DOCX, XLS, XLSX, PPT, PPTX.
-
-**Name**|**Required**|**Type**|**Description**|**Default**
------|-----|-----|-----|-----
-**FileName**|**X**|String|The document filename including extension. This is important as it is used to help identify the document MIME type.|
-**FileData**|**X**|Base64|The document encoded in Base64 format.|
-**Order** | | Integer|If multiple documents are defined on a message this value will determine the order in which they will be transmitted.|0|
-**DocMergeData**|||An Array of MergeFields|
-**StampMergeData**|||An Array of MergeFields|
 
 ***Resolution Levels:***
 
@@ -1008,3 +968,50 @@ All files are encoded in the Base64 encoding specified in RFC 2045 - MIME (Multi
 
 ### Dates
 Dates are always passed in ISO-8601 format with time zone. For example: “2012-07-17T19:27:23+08:00”
+
+### MonopondSendFaxRequest Properties
+**Name**|**Required**|**Type**|**Description**|**Default**
+-----|-----|-----|-----|-----
+**BroadcastRef**||String|Allows the user to tag all faxes in this request with a user-defined broadcastreference. These faxes can then be retrieved at a later point based on this reference.|
+**SendRef**||String|Similar to the BroadcastRef, this allows the user to tag all faxes in this request with a send reference. The SendRef is used to represent all faxes in this request only, so naturally it must be unique.|
+**FaxMessages**|**X**| Array of FaxMessage |FaxMessages describe each individual fax message and its destination. See below for details.|
+**SendFrom**||Alphanumeric String|A customisable string used to identify the sender of the fax. Also known as the Transmitting Subscriber Identification (TSID). The maximum string length is 32 characters|Fax
+**Documents**|**X**|Array of apiFaxDocument|Each FaxDocument object describes a fax document to be sent. Multiple documents can be defined here which will be concatenated and sent in the same message. See below for details.|
+**Resolution**||Resolution|Resolution setting of the fax document. Refer to the resolution table below for possible resolution values.|normal
+**ScheduledStartTime**||DateTime|The date and time the transmission of the fax will start.|Current time (immediate sending)
+**Blocklists**||Blocklists|The blocklists that will be checked and filtered against before sending the message. See below for details.WARNING: This feature is inactive and non-functional in this (2.1) version of the Fax API.|
+**Retries**||Unsigned Integer|The number of times to retry sending the fax if it fails. Each account has a maximum number of retries that can be changed by consultation with your account manager.|Account Default
+**BusyRetries**||Unsigned Integer|Certain fax errors such as “NO_ANSWER” or “BUSY” are not included in the above retries limit and can be set separately. Each account has a maximum number of busy retries that can be changed by consultation with your account manager.|Account default
+**HeaderFormat**||String|Allows the header format that appears at the top of the transmitted fax to be changed. See below for an explanation of how to format this field.| From: X, To: X
+**MustBeSentBeforeDate** | | DateTime |  Specifies a time the fax must be delivered by. Once the specified time is reached the fax will be cancelled across the system. | 
+**MaxFaxPages** | | Unsigned Integer |  Sets a limit on the amount of pages allowed in a single fax transmission. Especially useful if the user is blindly submitting their customer's documents to the platform. | 20
+
+### MonopondFaxMessage Properties
+This represents a single fax message being sent to a destination.
+
+**Name** | **Required** | **Type** | **Description** | **Default** 
+-----|-----|-----|-----|-----
+**MessageRef** | **X** | String | A unique user-provided identifier that is used to identify the fax message. This can be used at a later point to retrieve the results of the fax message. |
+**SendTo** | **X** | String | The phone number the fax message will be sent to. |
+**SendFrom** | | Alphanumeric String | A customisable string used to identify the sender of the fax. Also known as the Transmitting Subscriber Identification (TSID). The maximum string length is 32 characters | Empty
+**Documents** | **X** | Array of apiFaxDocument | Each FaxDocument object describes a fax document to be sent. Multiple documents can be defined here which will be concatenated and sent in the same message. See below for details. | 
+**Resolution** | | Resolution|Resolution setting of the fax document. Refer to the resolution table below for possible resolution values.| normal
+**ScheduledStartTime** | | DateTime | The date and time the transmission of the fax will start. | Start now
+**Blocklists** | | Blocklists | The blocklists that will be checked and filtered against before sending the message. See below for details. WARNING: This feature is inactive and non-functional in this (2.1) version of the Fax API. |
+**Retries** | | Unsigned Integer | The number of times to retry sending the fax if it fails. Each account has a maximum number of retries that can be changed by consultation with your account manager. | Account Default
+**BusyRetries** | | Unsigned Integer | Certain fax errors such as “NO_ANSWER” or “BUSY” are not included in the above retries limit and can be set separately. Please consult with your account manager in regards to maximum value.|account default
+**HeaderFormat** | | String | Allows the header format that appears at the top of the transmitted fax to be changed. See below for an explanation of how to format this field. | From： X, To: X
+**MustBeSentBeforeDate** | | DateTime |  Specifies a time the fax must be delivered by. Once the specified time is reached the fax will be cancelled across the system. | 
+**MaxFaxPages** | | Unsigned Integer |  Sets a limit on the amount of pages allowed in a single fax transmission. Especially useful if the user is blindly submitting their customer's documents to the platform. | 20
+**CLI**| | String| Allows a customer called ID. Note: Must be enabled on the account before it can be used.
+
+### MonopondDocument Properties
+Represents a fax document to be sent through the system. Supported file types are: PDF, TIFF, PNG, JPG, GIF, TXT, PS, RTF, DOC, DOCX, XLS, XLSX, PPT, PPTX.
+
+**Name**|**Required**|**Type**|**Description**|**Default**
+-----|-----|-----|-----|-----
+**FileName**|**X**|String|The document filename including extension. This is important as it is used to help identify the document MIME type.|
+**FileData**|**X**|Base64|The document encoded in Base64 format.|
+**Order** | | Integer|If multiple documents are defined on a message this value will determine the order in which they will be transmitted.|0|
+**DocMergeData**|||An Array of MergeFields|
+**StampMergeData**|||An Array of MergeFields|

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To send a fax to a single destination a request similar to the following example
 	$sendRespone = $client->sendFax($sendFaxRequest);
 	print_r($sendRespone);
 ```
-You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know there definitions:
+You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know the definitions:
 * [MonopondDocument Properties](#monoponddocument-properties)
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)

--- a/README.md
+++ b/README.md
@@ -666,6 +666,81 @@ You can visit here the definition of Blocklists and its paremeters:
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 * [Blocklists Parameters](#blocklists-parameters);
 
+### Sending a Fax with ScheduledStartTime in MonopondFaxMessage
+To set a ScheduledStartTime for the MonopondFaxMessage, a request similar to the following can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->ScheduledStartTime = "2017-06-25T12:00:00Z";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+    $faxMessage2->ScheduledStartTime = "2017-06-25T12:00:00Z";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+
+You can visit here the definition of ScheduledStartTime here:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+
+### Sending a Fax with ScheduledStartTime in MonopondSendFaxRequest
+To set a ScheduledStartTime for the MonopondSendFaxRequest, a request similar to the following can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->ScheduledStartTime = "2017-06-25T12:00:00Z";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+You can visit here the definition of ScheduledStartTime here:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -888,58 +888,56 @@ To set a MaxFaxPages for MonopondSendFaxRequest, a request similar to the follow
 To know more about MaxFaxPages you can check it here:
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-
 ### Sending multiple faxes:
-To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
+To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another `FaxMessage`:
 
 ```php
-// TODO: Put your file path here
- $filedata = fread(fopen("./test.txt", "r"), filesize("./test.txt"));
- $filedata = base64_encode($filedata);
- 
- // TODO: Setup Document
- $document = new MonopondDocument();
- $document->FileName = "AnyFileName1.txt";
- $document->FileData = $filedata;
- $document->Order = 0;
- $document2 = new MonopondDocument();
- $document2->FileName = "AnyFileName2.txt";
- $document2->FileData = $filedata;
- $document2->Order = 0;
- 
- $document3 = new MonopondDocument();
- $document3->FileName = "AnyFileName3.txt";
- $document3->FileData = $filedata;
- $document3->Order = 0;
- 
- // TODO: Setup FaxMessage
- $faxMessage = new MonopondFaxMessage();
- $faxMessage->MessageRef = "Testing-message-1";
- $faxMessage->SendTo = "61011111111";
- $faxMessage->SendFrom = "Test Fax";
- $faxMessage->Documents = array($document);
- $faxMessage->Resolution = "normal";
- $faxMessage->Retries = 0;
- $faxMessage->BusyRetries = 2;
- $faxMessage2 = new MonopondFaxMessage();
- $faxMessage2->MessageRef = "Testing-message-2";
- $faxMessage2->SendTo = "61011111111";
- $faxMessage2->SendFrom = "Test Fax 2";
- $faxMessage2->Documents = array($document $document3);
- $faxMessage2->Resolution = "normal";
- $faxMessage2->Retries = 0;
- $faxMessage2->BusyRetries = 3;
- // TODO: Setup FaxSendRequest 
- $sendFaxRequest = new MonopondSendFaxRequest();
- $sendFaxRequest->BroadcastRef = "Broadcast-test-1";
- $sendFaxRequest->SendRef = "Send-Ref-1";
- $sendFaxRequest->FaxMessages[] = $faxMessage;
- $sendFaxRequest->FaxMessages[] = $faxMessage2;
- 
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
 
- // Call send fax method
- $sendRespone = $client->sendFax($sendFaxRequest);
- print_r($sendRespone);
+    $document2 = new MonopondDocument();
+    $document2->FileName = "AnyFileName2.txt";
+    $document2->FileData = $filedata;
+    $document2->Order = 0;
+
+    $document3 = new MonopondDocument();
+    $document3->FileName = "AnyFileName3.txt";
+    $document3->FileData = $filedata;
+    $document3->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->Documents = $document;
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+    $faxMessage2->Documents = $document2;
+
+    $faxMessage3 = new MonopondFaxMessage();
+    $faxMessage3->MessageRef = "Testing-message-3";
+    $faxMessage3->SendTo = "61011111112";
+    $faxMessage3->Documents = $document3;
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2, $faxMessage3);
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
 ```
 
 ### Sending faxes to multiple destinations with the same document (broadcasting):

--- a/README.md
+++ b/README.md
@@ -164,37 +164,6 @@ This is what the file looks like after the fields ```field1```,```field2``` and 
 
 ![stamp](https://github.com/Monopond/fax-api/raw/master/img/DocMergeData/after.png)
 
-#### Sending a single fax
-A sample code must be similar to the following request below.
-
-```php
-	// TODO: Put your file path here
-    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
-    $filedata = base64_encode($filedata);
-    
-    /* Setup Documents */
-    $document = new MonopondDocument();
-    $document->FileName = "AnyFileName1.txt";
-    $document->FileData = $filedata;
-    $document->Order = 0;
-
-    $faxMessage = new MonopondFaxMessage();
-    $faxMessage->MessageRef = "Testing-message-1";
-    $faxMessage->SendTo = "61011111111";
-
-    $sendFaxRequest = new MonopondSendFaxRequest();
-    $sendFaxRequest->BroadcastRef = "Broadcast-test-1";
-    $sendFaxRequest->SendRef = "Send-Ref-1";
-    $sendFaxRequest->FaxMessages[] = $faxMessage;
-    $sendFaxRequest->Documents = array($document);
-
-    /* Send request to Monopond */
-    $sendRespone = $client->sendFax($sendFaxRequest);
-    /* Display response */
-    print_r($sendRespone);
-
-```
-
 ##### Sample Request
 The example below shows ```field1``` will be replaced by the value of ```Test```.
 

--- a/README.md
+++ b/README.md
@@ -309,9 +309,7 @@ You can visit the definition of Resolution and its values here:
 ### Sending a Fax with Resolution in MonopondSendFaxRequest
 To assign the fax resolution, a request similar to the following example can be used.
 ```php
-	// TODO: Enter your own credentials here
-    $client = new MonopondSOAPClientV2("monoponduser", "synacy22", MPENV::PRODUCTION_BETA);
-    
+	
     // TODO: Put your file path here
     $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
     $filedata = base64_encode($filedata);

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-### Assigning DocumentRef to MonopondDocument
+### Assigning DocumentRef in MonopondDocument
 DocumentRef must be unique and a request must be similar to this example:
 ```php
     // TODO: Put your file path here

--- a/README.md
+++ b/README.md
@@ -483,6 +483,38 @@ Allows the header format that appears at the top of the transmitted fax to be ch
 For more information, visit the following on how to setup the HeaderFormat value:
 * [Header Format](#header-format)
 
+### Assigning CLI in MonopondFaxMessage
+Assigning a CLI in the MonopondFaxMessage, a request similar to the following example below.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->CLI = "61011111111";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the definition of CLI here:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ The example below shows ```field1``` will be replaced by the value of ```Test```
 
 ```php
 	// TODO: Put your file path here
-    $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));
+	$filedata = fread(fopen("tests/sample.doc", "r"), filesize("tests/sample.doc"));
 	$filedata = base64_encode($filedata);
 
 	$mergeField = new MonopondMergeField();
@@ -1045,8 +1045,8 @@ The example below shows ```field1``` will be replaced by the value of ```Test```
 	$faxMessage2->Documents = array($document2);
 
 	$baseDocument = new MonopondDocument();
-	$baseDocument->DocumentRef = "send-1-document";
-	$baseDocument->FileName = "file.docx";
+	$baseDocument->DocumentRef = "send-1-document2";
+	$baseDocument->FileName = "file.doc";
 	$baseDocument->FileData = $filedata;
 	$baseDocument->Order = 0;
 
@@ -1060,148 +1060,9 @@ The example below shows ```field1``` will be replaced by the value of ```Test```
 	$sendFaxRequest->Documents = array($baseDocument);
 
 	/* Send request to Monopond */
-    $sendRespone = $client->sendFax($sendFaxRequest);
-    /* Display response */
-    print_r($sendRespone);
-```
-
-### Sending Fax with TimeZone
-The Timezone is used to format the datetime display in the fax header.
-```php
-	// TODO: Put your file path here
-    $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));
-	$filedata = base64_encode($filedata);
-
-	$mergeField = new MonopondMergeField();
-	$mergeField->Key = "name";
-	$mergeField->Value = "Raspberry Pi";
-
-	$document1 = new MonopondDocument();
-	$document1->DocumentRef = "send-1-document";
-	$document1->DocMergeData[] = $mergeField;
-
-	/* Setup FaxMessages (Each contains an array of document objects) */
-	$faxMessage = new MonopondFaxMessage();
-	$faxMessage->MessageRef = "message-1";
-	$faxMessage->SendTo = "61290120211";
-	$faxMessage->SendFrom = "Test Fax";
-	$faxMessage->Resolution = "normal";
-	$faxMessage->Retries = 0;
-	$faxMessage->BusyRetries = 2;
-	$faxMessage->CLI = 61290120211;
-	$faxMessage->Documents = array($document1);
-	$faxMessage->TimeZone = 'Australia/Sydney';
-
-	$mergeField2 = new MonopondMergeField();
-	$mergeField2->Key = "name";
-	$mergeField2->Value = "Raspberry Pi 2";
-
-	$document2 = new MonopondDocument();
-	$document2->DocumentRef = "send-1-document";
-	$document2->DocMergeData[] = $mergeField2;
-
-	$faxMessage2 = new MonopondFaxMessage();
-	$faxMessage2->MessageRef = "message-2";
-	$faxMessage2->SendTo = "61290120211";
-	$faxMessage2->SendFrom = "Test Fax 2";
-	$faxMessage2->Resolution = "normal";
-	$faxMessage2->Retries = 0;
-	$faxMessage2->BusyRetries = 2;
-	$faxMessage2->CLI = 61011114111;
-	$faxMessage2->Documents = array($document2);
-	$faxMessage2->TimeZone = 'Australia/Sydney';
-
-	$baseDocument = new MonopondDocument();
-	$baseDocument->DocumentRef = "send-1-document";
-	$baseDocument->FileName = "file.docx";
-	$baseDocument->FileData = $filedata;
-	$baseDocument->Order = 0;
-
-	/* Setup FaxSendRequest (Each contains an array of fax messages) */
-	$sendFaxRequest = new MonopondSendFaxRequest();
-	$sendFaxRequest->BroadcastRef = "broadcast-1";
-	$sendFaxRequest->SendRef = "send-1";
-	$sendFaxRequest->HeaderFormat = "Testing";
-	$sendFaxRequest->FaxMessages[] = $faxMessage;
-	$sendFaxRequest->FaxMessages[] = $faxMessage2;
-	$sendFaxRequest->Documents = array($baseDocument);
-
-	/* Send request to Monopond */
-    $sendRespone = $client->sendFax($sendFaxRequest);
-    /* Display response */
-    print_r($sendRespone);
-```
-
-### Sending Fax with Blocklist
-A sample request must be similar to this following code below:
-
-```php
-	// TODO: Put your file path here
-    $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));
-	$filedata = base64_encode($filedata);
-
-	$mergeField = new MonopondMergeField();
-	$mergeField->Key = "name";
-	$mergeField->Value = "Raspberry Pi";
-
-	$document1 = new MonopondDocument();
-	$document1->DocumentRef = "send-1-document";
-	$document1->DocMergeData[] = $mergeField;
-
-    $monopondBlocklist = new MonopondBlocklist();
-    $monopondBlocklist->dncr = "true";
-
-	/* Setup FaxMessages (Each contains an array of document objects) */
-	$faxMessage = new MonopondFaxMessage();
-	$faxMessage->MessageRef = "message-1";
-	$faxMessage->SendTo = "61290120211";
-	$faxMessage->SendFrom = "Test Fax";
-	$faxMessage->Resolution = "normal";
-	$faxMessage->Retries = 0;
-	$faxMessage->BusyRetries = 2;
-	$faxMessage->CLI = 61290120211;
-	$faxMessage->Documents = array($document1);
-	$faxMessage->TimeZone = 'Australia/Sydney';
-	$faxMessage->Blocklists = $monopondBlocklist;
-
-	$mergeField2 = new MonopondMergeField();
-	$mergeField2->Key = "name";
-	$mergeField2->Value = "Raspberry Pi 2";
-
-	$document2 = new MonopondDocument();
-	$document2->DocumentRef = "send-1-document";
-	$document2->DocMergeData[] = $mergeField2;
-
-	$faxMessage2 = new MonopondFaxMessage();
-	$faxMessage2->MessageRef = "message-2";
-	$faxMessage2->SendTo = "61290120211";
-	$faxMessage2->SendFrom = "Test Fax 2";
-	$faxMessage2->Resolution = "normal";
-	$faxMessage2->Retries = 0;
-	$faxMessage2->BusyRetries = 2;
-	$faxMessage2->CLI = 61011114111;
-	$faxMessage2->Documents = array($document2);
-	$faxMessage2->TimeZone = 'Australia/Sydney';
-
-	$baseDocument = new MonopondDocument();
-	$baseDocument->DocumentRef = "send-1-document";
-	$baseDocument->FileName = "file.docx";
-	$baseDocument->FileData = $filedata;
-	$baseDocument->Order = 0;
-
-	/* Setup FaxSendRequest (Each contains an array of fax messages) */
-	$sendFaxRequest = new MonopondSendFaxRequest();
-	$sendFaxRequest->BroadcastRef = "broadcast-1";
-	$sendFaxRequest->SendRef = "send-1";
-	$sendFaxRequest->HeaderFormat = "Testing";
-	$sendFaxRequest->FaxMessages[] = $faxMessage;
-	$sendFaxRequest->FaxMessages[] = $faxMessage2;
-	$sendFaxRequest->Documents = array($baseDocument);
-
-	/* Send request to Monopond */
-    $sendRespone = $client->sendFax($sendFaxRequest);
-    /* Display response */
-    print_r($sendRespone);
+	$sendRespone = $client->sendFax($sendFaxRequest);
+	/* Display response */
+	print_r($sendRespone);
 ```
 
 ### Sending Tiff and PDF files with StampMergeData:

--- a/README.md
+++ b/README.md
@@ -741,6 +741,80 @@ To set a ScheduledStartTime for the MonopondSendFaxRequest, a request similar to
 You can visit here the definition of ScheduledStartTime here:
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with MustBeSentBeforeDate in MonopondFaxMessage
+To set a MustBeSentBeforeDate for MonopondFaxMessage, a request similar to the following can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->MustBeSentBeforeDate = "2017-09-05T21:30:17+10:00";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+    $faxMessage2->MustBeSentBeforeDate = "2017-09-05T21:30:17+10:00";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+To know more about MustBeSentBeforeDate you can check it here:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+
+### Sending a Fax with MustBeSentBeforeDate in MonopondSendFaxRequest
+To set a MustBeSentBeforeDate for MonopondSendFaxRequest, a request similar to the following can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->MustBeSentBeforeDate = "2017-09-05T21:30:17+10:00";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+To know more about MustBeSentBeforeDate you can check it here:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,71 @@ The Timezone is used to format the datetime display in the fax header. Applying 
     print_r($sendRespone);
 ```
 
+### Assigning SendFrom in MonopondFaxMessage
+To send fax with SendFrom in MonopondFaxMessage a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->SendFrom = "Sample SendFrom";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the definition of SendFrom here:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+
+### Assigning SendFrom in MonopondSendFaxRequest
+To send fax with SendFrom in MonopondSendFaxRequest a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->SendFrom = "Test Example";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+You can visit the definition of SendFrom here:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:

--- a/README.md
+++ b/README.md
@@ -296,6 +296,63 @@ To set the fax FaxDitheringTechnique, a request similar to the following example
 You can visit the different values of FaxDitheringTechnique here:
 * [FaxDitheringTechniques](#faxditheringtechnique)
 
+### Assigning a Timezone in MonopondFaxMessage
+The Timezone is used to format the datetime display in the fax header.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->TimeZone = "Australia/Adelaide";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+### Assigning a Timezone in MonopondSendFaxRequest
+The Timezone is used to format the datetime display in the fax header. Applying it to the MonopondSendFaxRequest will apply this to all MonopondFaxMessages in the request.
+```php
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->TimeZone = "Australia/Adelaide";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,40 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with Retries inside a SendFaxRequest
+To set-up a fax to have retries a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->Retries = 1;
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know their definitions:
+* [MonopondDocument Properties](#monoponddocument-properties)
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-### Sending a Fax with Retries inside a FaxMessage
+### Sending a Fax with Retries inside a MonopondFaxMessage
 To set-up a fax to have retries a request similar to the following example can be used.
 
 ```php
@@ -91,7 +91,7 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-### Sending a Fax with Retries inside a SendFaxRequest
+### Sending a Fax with Retries inside a MonopondSendFaxRequest
 To set-up a fax to have retries a request similar to the following example can be used.
 ```php
     // TODO: Put your file path here
@@ -125,7 +125,7 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-### Sending a Fax with BusyRetries inside a FaxMessage
+### Sending a Fax with BusyRetries inside a MonopondFaxMessage
 To set-up a fax to have busyRetries a request similar to the following example can be used.
 ```php
     // TODO: Put your file path here
@@ -159,7 +159,7 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-### Sending a Fax with BusyRetries inside a SendFaxRequest
+### Sending a Fax with BusyRetries inside a MonopondSendFaxRequest
 To set-up a fax to have busyRetries a request similar to the following example can be used.
 ```php
     // TODO: Put your file path here
@@ -193,7 +193,7 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
-### Sending a Fax with Resolution in FaxMessage
+### Sending a Fax with Resolution in MonopondFaxMessage
 To assign the fax resolution, a request similar to the following example can be used.
 ```php
     // TODO: Put your file path here
@@ -227,6 +227,41 @@ You can visit the definition of Resolution and its values here:
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [Resolution Levels](#resolution-levels)
 
+### Sending a Fax with Resolution in MonopondSendFaxRequest
+To assign the fax resolution, a request similar to the following example can be used.
+```php
+	// TODO: Enter your own credentials here
+    $client = new MonopondSOAPClientV2("monoponduser", "synacy22", MPENV::PRODUCTION_BETA);
+    
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->Resolution = "fine";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the definition of Resolution and its values here:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+* [Resolution Levels](#resolution-levels)
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ To set the fax FaxDitheringTechnique, a request similar to the following example
 
 ```
 You can visit the different values of FaxDitheringTechnique here:
-* [FaxDitheringtechniques](#faxditheringtechniques)
+* [FaxDitheringTechniques](#faxditheringtechnique)
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To send a fax to a single destination a request similar to the following example
 You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know there definitions:
 * [MonopondDocument Properties](#monoponddocument-properties)
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
-* [MonopondSendFaxRequest Properties](#monopondsendfaxfequest-properties)
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
 
 ### Sending multiple faxes:

--- a/README.md
+++ b/README.md
@@ -417,6 +417,71 @@ To send fax with SendFrom in MonopondSendFaxRequest a request similar to the fol
 You can visit the definition of SendFrom here:
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Assigning a HeaderFormat in MonopondFaxMessage
+Allows the header format that appears at the top of the transmitted fax to be changed.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->HeaderFormat = "From %from%, To %to%|%a %b %d %H:%M %Y";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+For more information, visit the following on how to setup the HeaderFormat value:
+* [Header Format](#header-format)
+
+### Assigning a HeaderFormat in MonopondSendFaxRequest
+Allows the header format that appears at the top of the transmitted fax to be changed.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->HeaderFormat = "From %from%, To %to%|%a %b %d %H:%M %Y";
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+
+For more information, visit the following on how to setup the HeaderFormat value:
+* [Header Format](#header-format)
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
@@ -755,37 +820,6 @@ The example below shows a PDF that will be stamped with the text “Hello” at 
 ```php
 	TODO: code here  
 ```
-
-***Header Format:iff***
-Determines the format of the header line that is printed on the top of the transmitted fax message.
-This is set to **rom %from%, To %to%|%a %b %d %H:%M %Y”**y default which produces the following:
-
-From TSID, To 61022221234 Mon Aug 28 15:32 2012 1 of 1
-
-**Value** | **Description**
---- | ---
-**%from%**|The value of the **SendFrom** field in the message.
-**%to%**|The value of the **SendTo** field in the message.
-**%a**|Weekday name (abbreviated)
-**%A**|Weekday name
-**%b**|Month name (abbreviated)
-**%B**|Month name
-**%d**|Day of the month as a decimal (01 – 31)
-**%m**|Month as a decimal (01 – 12)
-**%y**|Year as a decimal (abbreviated)
-**%Y**|Year as a decimal
-**%H**|Hour as a decimal using a 24-hour clock (00 – 23)
-**%I**|Hour as a decimal using a 12-hour clock (01 – 12)
-**%M**|Minute as a decimal (00 – 59)
-**%S**|Second as a decimal (00 – 59)
-**%p**|AM or PM
-**%j**|Day of the year as a decimal (001 – 366)
-**%U**|Week of the year as a decimal (Monday as first day of the week) (00 – 53)
-**%W**|Day of the year as a decimal (001 – 366)
-**%w**|Day of the week as a decimal (0 – 6) (Sunday being 0)
-**%%**|A literal % character
-
-TODO: The default value is set to: “From %from%, To %to%|%a %b %d %H:%M %Y”
 
 <a name="docMergeDataParameters"></a> 
 
@@ -1365,3 +1399,34 @@ Represents a fax document to be sent through the system. Supported file types ar
 | **lighten_more** | Lighten more dithering. |
 | **crosshatch** | Crosshatch dithering. |
 | **DETAILED** | Detailed dithering. |
+
+### Header Format
+Determines the format of the header line that is printed on the top of the transmitted fax message.
+This is set to **rom %from%, To %to%|%a %b %d %H:%M %Y”**y default which produces the following:
+
+From TSID, To 61022221234 Mon Aug 28 15:32 2012 1 of 1
+
+**Value** | **Description**
+--- | ---
+**%from%**|The value of the **SendFrom** field in the message.
+**%to%**|The value of the **SendTo** field in the message.
+**%a**|Weekday name (abbreviated)
+**%A**|Weekday name
+**%b**|Month name (abbreviated)
+**%B**|Month name
+**%d**|Day of the month as a decimal (01 – 31)
+**%m**|Month as a decimal (01 – 12)
+**%y**|Year as a decimal (abbreviated)
+**%Y**|Year as a decimal
+**%H**|Hour as a decimal using a 24-hour clock (00 – 23)
+**%I**|Hour as a decimal using a 12-hour clock (01 – 12)
+**%M**|Minute as a decimal (00 – 59)
+**%S**|Second as a decimal (00 – 59)
+**%p**|AM or PM
+**%j**|Day of the year as a decimal (001 – 366)
+**%U**|Week of the year as a decimal (Monday as first day of the week) (00 – 53)
+**%W**|Day of the year as a decimal (001 – 366)
+**%w**|Day of the week as a decimal (0 – 6) (Sunday being 0)
+**%%**|A literal % character
+
+TODO: The default value is set to: “From %from%, To %to%|%a %b %d %H:%M %Y”

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use Monopond SOAP PHP Client, start by including the `MonopondSOAPClient.php`
      include_once './MonopondSOAPClient.php';
      
      // TODO: Enter your own credentials here
-     $client = new MonopondSOAPClientV2("myusername", "mypassword", MPENV::PRODUCTION);
+     $client = new MonopondSOAPClientV2_1("myusername", "mypassword", MPENV::PRODUCTION);
      
      // TODO: Set up your request here
  ?>

--- a/README.md
+++ b/README.md
@@ -159,6 +159,40 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with BusyRetries inside a SendFaxRequest
+To set-up a fax to have busyRetries a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->BusyRetries = 1;
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know their definitions:
+* [MonopondDocument Properties](#monoponddocument-properties)
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -947,34 +947,43 @@ This method is recommended for broadcasting as it takes advantage of the multipl
 When sending multiple faxes in batch it is recommended to group them into requests of around 600 fax messages for optimal performance. If you are sending the same document to multiple destinations it is strongly advised to only attach the document once in the root of the send request rather than attaching a document for each destination.
 
 ```php
- // TODO: Put your file path here
- $filedata = fread(fopen("./test.txt", "r"), filesize("./test.txt"));
- $filedata = base64_encode($filedata);
- 
- // TODO: Setup Document
- $document = new MonopondDocument();
- $document->FileName = "AnyFileName1.txt";
- $document->FileData = $filedata;
- $document->Order = 0;
- 
- // TODO: Setup FaxMessage
- $faxMessage = new MonopondFaxMessage();
- $faxMessage->MessageRef = "Testing-message-1";
- $faxMessage->SendTo = "61011111111";
- $faxMessage2 = new MonopondFaxMessage();
- $faxMessage2->MessageRef = "Testing-message-2";
- $faxMessage2->SendTo = "61011111111";
- // TODO: Setup FaxSendRequest 
- $sendFaxRequest = new MonopondSendFaxRequest();
- $sendFaxRequest->BroadcastRef = "Broadcast-test-1";
- $sendFaxRequest->SendRef = "Send-Ref-1";
- $sendFaxRequest->FaxMessages[] = $faxMessage;
- $sendFaxRequest->FaxMessages[] = $faxMessage2;
- $sendFaxRequest->Documents = array($document);
- $sendFaxRequest->SendFrom = "Test Fax";
- // Call send fax method
- $sendRespone = $client->sendFax($sendFaxRequest);
- print_r($sendRespone);
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    $document2 = new MonopondDocument();
+    $document2->FileName = "AnyFileName1.txt";
+    $document2->FileData = $filedata;
+    $document2->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+
+    $faxMessage3 = new MonopondFaxMessage();
+    $faxMessage3->MessageRef = "Testing-message-3";
+    $faxMessage3->SendTo = "61011111112";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2, $faxMessage3);
+    $sendFaxRequest->Documents = array($document, $document2);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
 ```
 
 ### Sending Microsoft Documents With DocMergeData:

--- a/README.md
+++ b/README.md
@@ -892,8 +892,11 @@ To know more about MaxFaxPages you can check it here:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another `FaxMessage`:
 
 ```php
+    // TODO: Enter your own credentials here
+    $client = new MonopondSOAPClientV2("monoponduser", "synacy22", MPENV::PRODUCTION_BETA);
+    
     // TODO: Put your file path here
-    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = fread(fopen("tests/hello.txt", "r"), filesize("tests/hello.txt"));
     $filedata = base64_encode($filedata);
     
     /* Setup Documents */
@@ -916,22 +919,21 @@ To send faxes to multiple destinations a request similar to the following exampl
     $faxMessage = new MonopondFaxMessage();
     $faxMessage->MessageRef = "Testing-message-1";
     $faxMessage->SendTo = "61011111111";
-    $faxMessage->Documents = $document;
+    $faxMessage->Documents[] = $document;
 
     $faxMessage2 = new MonopondFaxMessage();
     $faxMessage2->MessageRef = "Testing-message-2";
     $faxMessage2->SendTo = "61011111112";
-    $faxMessage2->Documents = $document2;
+    $faxMessage2->Documents[] = $document2;
 
     $faxMessage3 = new MonopondFaxMessage();
     $faxMessage3->MessageRef = "Testing-message-3";
     $faxMessage3->SendTo = "61011111112";
-    $faxMessage3->Documents = $document3;
+    $faxMessage3->Documents[] = $document3;
 
     /* Setup FaxSendRequest (Each contains an array of fax messages) */
     $sendFaxRequest = new MonopondSendFaxRequest();
     $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2, $faxMessage3);
-    $sendFaxRequest->Documents = array($document);
 
     /* Send request to Monopond */
     $sendRespone = $client->sendFax($sendFaxRequest);

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ DocumentRef must be unique and a request must be similar to this example:
     $document2->FileName = "AnyFileName1.txt";
     $document2->FileData = $filedata;
     $document2->Order = 0;
-    $document->DocumentRef = "Sample DocumentRef2";
+    $document2->DocumentRef = "Sample DocumentRef2";
 
     /* Setup FaxMessages (Each contains an array of document objects) */
     $faxMessage = new MonopondFaxMessage();

--- a/README.md
+++ b/README.md
@@ -229,6 +229,145 @@ The example below shows ```field1``` will be replaced by the value of ```Test```
     /* Display response */
     print_r($sendRespone);
 ```
+
+### Sending Fax with TimeZone
+The Timezone is used to format the datetime display in the fax header.
+```php
+	// TODO: Put your file path here
+    $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));
+	$filedata = base64_encode($filedata);
+
+	$mergeField = new MonopondMergeField();
+	$mergeField->Key = "name";
+	$mergeField->Value = "Raspberry Pi";
+
+	$document1 = new MonopondDocument();
+	$document1->DocumentRef = "send-1-document";
+	$document1->DocMergeData[] = $mergeField;
+
+	/* Setup FaxMessages (Each contains an array of document objects) */
+	$faxMessage = new MonopondFaxMessage();
+	$faxMessage->MessageRef = "message-1";
+	$faxMessage->SendTo = "61290120211";
+	$faxMessage->SendFrom = "Test Fax";
+	$faxMessage->Resolution = "normal";
+	$faxMessage->Retries = 0;
+	$faxMessage->BusyRetries = 2;
+	$faxMessage->CLI = 61290120211;
+	$faxMessage->Documents = array($document1);
+	$faxMessage->TimeZone = 'Australia/Sydney';
+
+	$mergeField2 = new MonopondMergeField();
+	$mergeField2->Key = "name";
+	$mergeField2->Value = "Raspberry Pi 2";
+
+	$document2 = new MonopondDocument();
+	$document2->DocumentRef = "send-1-document";
+	$document2->DocMergeData[] = $mergeField2;
+
+	$faxMessage2 = new MonopondFaxMessage();
+	$faxMessage2->MessageRef = "message-2";
+	$faxMessage2->SendTo = "61290120211";
+	$faxMessage2->SendFrom = "Test Fax 2";
+	$faxMessage2->Resolution = "normal";
+	$faxMessage2->Retries = 0;
+	$faxMessage2->BusyRetries = 2;
+	$faxMessage2->CLI = 61011114111;
+	$faxMessage2->Documents = array($document2);
+	$faxMessage2->TimeZone = 'Australia/Sydney';
+
+	$baseDocument = new MonopondDocument();
+	$baseDocument->DocumentRef = "send-1-document";
+	$baseDocument->FileName = "file.docx";
+	$baseDocument->FileData = $filedata;
+	$baseDocument->Order = 0;
+
+	/* Setup FaxSendRequest (Each contains an array of fax messages) */
+	$sendFaxRequest = new MonopondSendFaxRequest();
+	$sendFaxRequest->BroadcastRef = "broadcast-1";
+	$sendFaxRequest->SendRef = "send-1";
+	$sendFaxRequest->HeaderFormat = "Testing";
+	$sendFaxRequest->FaxMessages[] = $faxMessage;
+	$sendFaxRequest->FaxMessages[] = $faxMessage2;
+	$sendFaxRequest->Documents = array($baseDocument);
+
+	/* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+
+### Sending Fax with Blocklist
+A request must be 
+```php
+	// TODO: Put your file path here
+    $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));
+	$filedata = base64_encode($filedata);
+
+	$mergeField = new MonopondMergeField();
+	$mergeField->Key = "name";
+	$mergeField->Value = "Raspberry Pi";
+
+	$document1 = new MonopondDocument();
+	$document1->DocumentRef = "send-1-document";
+	$document1->DocMergeData[] = $mergeField;
+
+    $monopondBlocklist = new MonopondBlocklist();
+    $monopondBlocklist->dncr = "true";
+
+	/* Setup FaxMessages (Each contains an array of document objects) */
+	$faxMessage = new MonopondFaxMessage();
+	$faxMessage->MessageRef = "message-1";
+	$faxMessage->SendTo = "61290120211";
+	$faxMessage->SendFrom = "Test Fax";
+	$faxMessage->Resolution = "normal";
+	$faxMessage->Retries = 0;
+	$faxMessage->BusyRetries = 2;
+	$faxMessage->CLI = 61290120211;
+	$faxMessage->Documents = array($document1);
+	$faxMessage->TimeZone = 'Australia/Sydney';
+	$faxMessage->Blocklists = $monopondBlocklist;
+
+	$mergeField2 = new MonopondMergeField();
+	$mergeField2->Key = "name";
+	$mergeField2->Value = "Raspberry Pi 2";
+
+	$document2 = new MonopondDocument();
+	$document2->DocumentRef = "send-1-document";
+	$document2->DocMergeData[] = $mergeField2;
+
+	$faxMessage2 = new MonopondFaxMessage();
+	$faxMessage2->MessageRef = "message-2";
+	$faxMessage2->SendTo = "61290120211";
+	$faxMessage2->SendFrom = "Test Fax 2";
+	$faxMessage2->Resolution = "normal";
+	$faxMessage2->Retries = 0;
+	$faxMessage2->BusyRetries = 2;
+	$faxMessage2->CLI = 61011114111;
+	$faxMessage2->Documents = array($document2);
+	$faxMessage2->TimeZone = 'Australia/Sydney';
+
+	$baseDocument = new MonopondDocument();
+	$baseDocument->DocumentRef = "send-1-document";
+	$baseDocument->FileName = "file.docx";
+	$baseDocument->FileData = $filedata;
+	$baseDocument->Order = 0;
+
+	/* Setup FaxSendRequest (Each contains an array of fax messages) */
+	$sendFaxRequest = new MonopondSendFaxRequest();
+	$sendFaxRequest->BroadcastRef = "broadcast-1";
+	$sendFaxRequest->SendRef = "send-1";
+	$sendFaxRequest->HeaderFormat = "Testing";
+	$sendFaxRequest->FaxMessages[] = $faxMessage;
+	$sendFaxRequest->FaxMessages[] = $faxMessage2;
+	$sendFaxRequest->Documents = array($baseDocument);
+
+	/* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+
 ### Sending Tiff and PDF files with StampMergeData:
 (This request only works in version 2.1(or higher) of the fax-api.)
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,39 @@ You can visit the definition of Resolution and its values here:
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 * [Resolution Levels](#resolution-levels)
 
+### Sending a Fax with FaxDitheringTechnique in MonopondDocument:
+To set the fax FaxDitheringTechnique, a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    $document->DitheringTechnique = "turbo";
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+You can visit the different values of FaxDitheringTechnique here:
+* [FaxDitheringtechniques](#faxditheringtechniques
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 
@@ -1059,29 +1092,6 @@ TODO: code here
 |**fileName** |  | *String* | The document filename including extension. This is important as it is used to help identify the document MIME type. |
 |**fileData** |  | *Base64* | The document encoded in Base64 format. |
 
-**FaxDitheringTechnique:**
-
-| Value | Fax Dithering Technique |
-| --- | --- |
-| **none** | No dithering. |
-| **normal** | Normal dithering.|
-| **turbo** | Turbo dithering.|
-| **darken** | Darken dithering.|
-| **darken_more** | Darken more dithering.|
-| **darken_extra** | Darken extra dithering.|
-| **lighten** | Lighten dithering.|
-| **lighten_more** | Lighten more dithering. |
-| **crosshatch** | Crosshatch dithering. |
-| **DETAILED** | Detailed dithering. |
-
-**Resolution Levels:**
-
-| **Value** | **Description** |
-| --- | --- |
-| **normal** | Normal standard resolution (98 scan lines per inch) |
-| **fine** | Fine resolution (196 scan lines per inch) |
-
-### Response
 **FaxDocumentPreviewResponse**
 
 **Name** | **Type** | **Description** 
@@ -1218,3 +1228,18 @@ Represents a fax document to be sent through the system. Supported file types ar
 | --- | --- |
 | **normal** | Normal standard resolution (98 scan lines per inch) |
 | **fine** | Fine resolution (196 scan lines per inch) |
+
+### FaxDitheringTechnique
+
+| Value | Fax Dithering Technique |
+| --- | --- |
+| **none** | No dithering. |
+| **normal** | Normal dithering.|
+| **turbo** | Turbo dithering.|
+| **darken** | Darken dithering.|
+| **darken_more** | Darken more dithering.|
+| **darken_extra** | Darken extra dithering.|
+| **lighten** | Lighten dithering.|
+| **lighten_more** | Lighten more dithering. |
+| **crosshatch** | Crosshatch dithering. |
+| **DETAILED** | Detailed dithering. |

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ To set the fax FaxDitheringTechnique, a request similar to the following example
 
 ```
 You can visit the different values of FaxDitheringTechnique here:
-* [FaxDitheringtechniques](#faxditheringtechniques
+* [FaxDitheringtechniques](#faxditheringtechniques)
 
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:

--- a/README.md
+++ b/README.md
@@ -815,6 +815,80 @@ To set a MustBeSentBeforeDate for MonopondSendFaxRequest, a request similar to t
 To know more about MustBeSentBeforeDate you can check it here:
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with MaxFaxPages in MonopondFaxMessage
+To set a MaxFaxPages for MonopondFaxMessage, a request similar to the following can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->MaxFaxPages = 1;
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+    $faxMessage2->MaxFaxPages = 2;
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+To know more about MaxFaxPages you can check it here:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+
+### Sending a Fax with MaxFaxPages in MonopondSendFaxRequest
+To set a MaxFaxPages for MonopondSendFaxRequest, a request similar to the following can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2);
+    $sendFaxRequest->Documents = array($document);
+    $sendFaxRequest->MaxFaxPages = 2;
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+To know more about MaxFaxPages you can check it here:
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -27,37 +27,29 @@ Your specific faxing requirements will dictate which send request type below sho
 To send a fax to a single destination a request similar to the following example can be used:
 
 ```php
-// TODO: Put your file path here
- $filedata = fread(fopen("./test.txt", "r"), filesize("./test.txt"));
- $filedata = base64_encode($filedata);
- 
- // TODO: Setup Document
- $document = new MonopondDocument();
- $document->FileName = "AnyFileName1.txt";
- $document->FileData = $filedata;
- $document->Order = 0;
- 
- // TODO: Setup FaxMessage
- $faxMessage = new MonopondFaxMessage();
- $faxMessage->MessageRef = "Testing-message-1";
- $faxMessage->SendTo = "61011111111";
- $faxMessage->SendFrom = "Test Fax";
- $faxMessage->Documents = array($document);
- $faxMessage->Resolution = "normal";
- $faxMessage->Retries = 0;
- $faxMessage->BusyRetries = 2;
- $faxMessage->CLI = 123456;
- 
- // TODO: Setup FaxSendRequest 
- $sendFaxRequest = new MonopondSendFaxRequest();
- $sendFaxRequest->BroadcastRef = "Broadcast-test-1";
- $sendFaxRequest->SendRef = "Send-Ref-1";
- $sendFaxRequest->FaxMessages[] = $faxMessage;
- $sendFaxRequest->CLI = 65432;
+	// TODO: Put your file path here
+	$filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+	$filedata = base64_encode($filedata);
+    
+	// TODO: Setup Document
+	$document = new MonopondDocument();
+	$document->FileName = "AnyFileName1.txt";
+	$document->FileData = $filedata;
+	$document->Order = 0;
+     
+	// TODO: Setup FaxMessage
+	$faxMessage = new MonopondFaxMessage();
+	$faxMessage->MessageRef = "Testing-message-1";
+	$faxMessage->SendTo = "61011111111";
+	$faxMessage->Documents = array($document);
+     
+	// TODO: Setup FaxSendRequest 
+	$sendFaxRequest = new MonopondSendFaxRequest();
+	$sendFaxRequest->FaxMessages[] = $faxMessage;
 
- // Call send fax method
- $sendRespone = $client->sendFax($sendFaxRequest);
- print_r($sendRespone);
+	// Call send fax method
+	$sendRespone = $client->sendFax($sendFaxRequest);
+	print_r($sendRespone);
 ```
 
 ### Sending multiple faxes:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,40 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Sending a Fax with BusyRetries inside a FaxMessage
+To set-up a fax to have busyRetries a request similar to the following example can be used.
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->BusyRetries = 1;
+    
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit the following properties of MonopondDocument, MonopondFaxMessage, and MonopondSendFaxRequest to know their definitions:
+* [MonopondDocument Properties](#monoponddocument-properties)
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,37 @@ This is what the file looks like after the fields ```field1```,```field2``` and 
 
 ![stamp](https://github.com/Monopond/fax-api/raw/master/img/DocMergeData/after.png)
 
+#### Sending a single fax
+A sample code must be similar to the following request below.
+
+```php
+	// TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->BroadcastRef = "Broadcast-test-1";
+    $sendFaxRequest->SendRef = "Send-Ref-1";
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+
 ##### Sample Request
 The example below shows ```field1``` will be replaced by the value of ```Test```.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,52 @@ You can visit the following properties of MonopondDocument, MonopondFaxMessage, 
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 * [MonopondSendFaxRequest Properties](#monopondsendfaxrequest-properties)
 
+### Assigning DocumentRef to MonopondDocument
+DocumentRef must be unique and a request must be similar to this example:
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    $document->DocumentRef = "Sample DocumentRef";
+
+    $document2 = new MonopondDocument();
+    $document2->FileName = "AnyFileName1.txt";
+    $document2->FileData = $filedata;
+    $document2->Order = 0;
+    $document->DocumentRef = "Sample DocumentRef2";
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+
+    $faxMessage2 = new MonopondFaxMessage();
+    $faxMessage2->MessageRef = "Testing-message-2";
+    $faxMessage2->SendTo = "61011111112";
+
+    $faxMessage3 = new MonopondFaxMessage();
+    $faxMessage3->MessageRef = "Testing-message-3";
+    $faxMessage3->SendTo = "61011111112";
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages = array($faxMessage, $faxMessage2, $faxMessage3);
+    $sendFaxRequest->Documents = array($document, $document2);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit here to check the definition of DocumentRef:
+* [MonopondDocument Properties](#monoponddocument-properties)
+
 ### Sending a Fax with Retries inside a MonopondFaxMessage
 To set-up a fax to have retries a request similar to the following example can be used.
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ The Timezone is used to format the datetime display in the fax header.
 ```
 
 ### Sending Fax with Blocklist
-A request must be 
+A sample request must be similar to this following code below:
+
 ```php
 	// TODO: Put your file path here
     $filedata = fread(fopen("./test.docx", "r"), filesize("./test.docx"));

--- a/README.md
+++ b/README.md
@@ -515,6 +515,119 @@ Assigning a CLI in the MonopondFaxMessage, a request similar to the following ex
 You can visit the definition of CLI here:
 * [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
 
+### Sending a Fax with DNCR enabled in MonopondFaxMessage
+To check if a number is on the Do Not Call Register (Australian) before the fax is sent:
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup Blocklists */
+    $monopondBlocklists = new MonopondBlocklist();
+    $monopondBlocklists->dncr = "true";
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->Blocklists = $monopondBlocklists;
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+You can visit here the definition of Blocklists and its paremeters:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [Blocklists Parameters](#blocklists-parameters);
+
+### Sending a Fax with FPS enabled in MonopondFaxMessage
+To check if a number is on the FPS blacklist (UK) before the fax is sent:
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup Blocklists */
+    $monopondBlocklists = new MonopondBlocklist();
+    $monopondBlocklists->fps = "true";
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->Blocklists = $monopondBlocklists;
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+```
+You can visit here the definition of Blocklists and its paremeters:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [Blocklists Parameters](#blocklists-parameters);
+
+### Sending a Fax with Smartblock enabled in MonopondFaxMessage
+To check if a number is on the Smartblock list before the fax is sent:
+```php
+    // TODO: Put your file path here
+    $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));
+    $filedata = base64_encode($filedata);
+    
+    /* Setup Documents */
+    $document = new MonopondDocument();
+    $document->FileName = "AnyFileName1.txt";
+    $document->FileData = $filedata;
+    $document->Order = 0;
+    
+    /* Setup Blocklists */
+    $monopondBlocklists = new MonopondBlocklist();
+    $monopondBlocklists->smartblock = "true";
+
+    /* Setup FaxMessages (Each contains an array of document objects) */
+    $faxMessage = new MonopondFaxMessage();
+    $faxMessage->MessageRef = "Testing-message-1";
+    $faxMessage->SendTo = "61011111111";
+    $faxMessage->Blocklists = $monopondBlocklists;
+
+    /* Setup FaxSendRequest (Each contains an array of fax messages) */
+    $sendFaxRequest = new MonopondSendFaxRequest();
+    $sendFaxRequest->FaxMessages[] = $faxMessage;
+    $sendFaxRequest->Documents = array($document);
+
+    /* Send request to Monopond */
+    $sendRespone = $client->sendFax($sendFaxRequest);
+    /* Display response */
+    print_r($sendRespone);
+
+```
+You can visit here the definition of Blocklists and its paremeters:
+* [MonopondFaxMessage Properties](#monopondfaxmessage-properties)
+* [Blocklists Parameters](#blocklists-parameters);
+
 ### Sending multiple faxes:
 To send faxes to multiple destinations a request similar to the following example can be used. Please note the addition of another “FaxMessage”:
 
@@ -1215,7 +1328,6 @@ When making a resume request, you must provide at least a `BroadcastRef`, `SendR
  print_r($resumeFax);
 ```
 
-
 ### Response
 The response received from a `ResumeFaxRequest` is the same response you would receive when calling the `FaxStatus` method call with the `send` verbosity level. 
 
@@ -1462,3 +1574,11 @@ From TSID, To 61022221234 Mon Aug 28 15:32 2012 1 of 1
 **%%**|A literal % character
 
 TODO: The default value is set to: “From %from%, To %to%|%a %b %d %H:%M %Y”
+
+### Blocklists Parameters
+
+| **Name** | **Required** | **Type** | **Description** |
+| --- | --- | --- | --- |
+| **smartblock** | false | boolean | Blocks sending to a number if it has consistently failed in the past. |
+| **fps** | false | boolean | Wash numbers against the fps blocklist. |
+| **dncr** | false | boolean | Wash numbers against the dncr blocklist. |

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
     include_once './MonopondSOAPClient.php';
     
     // TODO: Enter your own credentials here
-    $client = new MonopondSOAPClientV2("username", "password", MPENV::PRODUCTION);
+    $client = new MonopondSOAPClientV2_1("username", "password", MPENV::PRODUCTION);
     
     // TODO: Put your file path here
     $filedata = fread(fopen("tests/sample.txt", "r"), filesize("tests/sample.txt"));

--- a/tests/MonopondSOAPClientTest.php
+++ b/tests/MonopondSOAPClientTest.php
@@ -2,7 +2,7 @@
 
     require_once dirname(__FILE__) . '/../MonopondSOAPClient.php';
 
-class MonopondSOAPClientV2Test extends PHPUnit_Framework_TestCase {
+class MonopondSOAPClientV2_1Test extends PHPUnit_Framework_TestCase {
 
     public function testFaxStatusWithBriefVerbosity(){
     	$client = $this->getMockFromWsdl('faxapi-v2.wsdl', 'faxStatus');
@@ -407,7 +407,7 @@ class MonopondSOAPClientV2Test extends PHPUnit_Framework_TestCase {
     public function testSendFaxSendSingleFax(){
     	//needs actual connection
     	//replace with valid username and password
-    	$client = new MonopondSOAPClientV2("user", "password", MPENV::Local);
+    	$client = new MonopondSOAPClientV2_1("user", "password", MPENV::Local);
     	$filedata = fread(fopen("./tests/sample.txt", "r"), filesize("./tests/sample.txt"));
     	$filedata = base64_encode($filedata);
 
@@ -438,7 +438,7 @@ class MonopondSOAPClientV2Test extends PHPUnit_Framework_TestCase {
     public function testSendFaxMultipleFaxes(){
 	//needs actual connection
     	//replace with valid username and password
-    	$client = new MonopondSOAPClientV2("user", "password", MPENV::Local);
+    	$client = new MonopondSOAPClientV2_1("user", "password", MPENV::Local);
     	$filedata = fread(fopen("./tests/sample.txt", "r"), filesize("./tests/sample.txt"));
     	$filedata = base64_encode($filedata);
 
@@ -489,7 +489,7 @@ class MonopondSOAPClientV2Test extends PHPUnit_Framework_TestCase {
     public function testSendFaxSendBroadcast(){
     	//needs actual connection
     	//replace with valid username and password
-    	$client = new MonopondSOAPClientV2("user", "password", MPENV::Local);
+    	$client = new MonopondSOAPClientV2_1("user", "password", MPENV::Local);
     	$filedata = fread(fopen("./tests/sample.txt", "r"), filesize("./tests/sample.txt"));
     	$filedata = base64_encode($filedata);
 


### PR DESCRIPTION
Hi @froilan, @jcfrancisco17, @timkhoury 

Scenarios to be tested:
* Sending a Fax with Timezone in FaxMessage.
* Sending a Fax with Timezone in SendFaxRequest.
* Sending a Fax with DocumentRef.
* Sending a Fax with FaxDitheringTechnique.
* Sending a Fax with MustBeSentBeforeDate in FaxMessage.
* Sending a Fax with MustBeSentBeforeDate in SendFaxRequest.
* Sending a Fax with MaxFaxPages in FaxMessage.
* Sending a Fax with MaxFaxPages in SendFaxRequest.
* Sending a Fax with CLI in FaxMessage
* Sending a Fax with CLI in SendFaxRequest
*  Sending a Fax with SendFrom in FaxMessage
* Sending a Fax with SendFrom in SendFaxRequest
* Sending a Fax with Resolution in SendFaxRequest
* Sending a Fax with Resolution in FaxMessage
* Sending a Fax with Blocklists in FaxMessage
* Sending a Fax with Blocklists in SendFaxRequest
* Sending a Fax with DocMergeData
* Sending a Fax with ScheduledStartTime in FaxMessage
* Sending a Fax with ScheduledStartTime in SendFaxRequest
* Sending a Fax with retries in FaxMessage
* Sending a Fax with retries in SendFaxRequest
* Sending a Fax with BusyRetries in FaxMessage
* Sending a Fax with BusyRetries in SendFaxRequest
* Sending a Fax with HeaderFormat in FaxMessage
* Sending a Fax with HeaderFormat in SendFaxRequest
* FaxStatusRequest
* Resume send fax
* Stop fax

Features to be implemented to other branch:
* StampMergeField
* SavedFaxDocument
* FaxDocumentPreview
* DeleteFaxDocument

Cheers,
Michael