### PR TITLE
arrange the xml elements of ApiDocument

### DIFF
--- a/MonopondSOAPClient.php
+++ b/MonopondSOAPClient.php
@@ -252,11 +252,11 @@ class MonopondSOAPClientV2 {
 	}
 
 	class MonopondDocument {
+		public $DocumentRef;
 		public $FileName;
 		public $FileData;
 		public $Order;
 		public $DocMergeData;
-		public $DocumentRef;
 	}
 
 	class MonopondFaxMessage {


### PR DESCRIPTION
Arrange the xml elements of ApiDocument.

It mus fix this error:
```
synacy7@synacy7:~/workspace/fax-api-client-php$ php index.php

Unmarshalling Error: cvc-complex-type.2.4.a: Invalid content was found starting with element 'DocumentRef'. One of '{StampMergeData}' is expected. PHP Notice:  Trying to get property of non-object in /home/synacy7/workspace/fax-api-client-php/MonopondSOAPClient.php on line 370
PHP Warning:  Invalid argument supplied for foreach() in /home/synacy7/workspace/fax-api-client-php/MonopondSOAPClient.php on line 370
MonopondSendFaxResponse Object
(
    [FaxMessages] => 
)

```